### PR TITLE
Typos and small changes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ Takes JSON object in from scanning application
 - qr_decode (Required)
  Representation of QR Data with no processing attached
 
- For instance, a smart healthcard would just upload data  in the form of of shc:1234
+ For instance, a smart healthcard would just upload data in the form of shc:1234
 
  In case of binary data, data shall be uploaded as Base64
 
@@ -53,7 +53,7 @@ Takes JSON object in from scanning application
 
 200 OK used to represent success (green check) validation.
 
-JSON object that contains the the following fields
+JSON object that contains the following fields
 
 - card_validity
 - first_name

--- a/docs/hardware_deployment_stuff.md
+++ b/docs/hardware_deployment_stuff.md
@@ -28,9 +28,9 @@ An important factor is this needs to be entirely turnkey. You download a pre-mad
 
 ## Ubuntu Core Based Solution
 
-The use of Ubuntu Core as a base has all the needed dependencies pre-packaged, and is trivial to deploy Docker containers on.
+The use of [Ubuntu Core](https://ubuntu.com/core) as a base has all the needed dependencies pre-packaged, and is trivial to deploy Docker containers on.
 
-It also allows easy upscaling to other machines, support for RPi, and general familiarity. Ubuntu Core offers "Ubuntu Frame" as a key solution to host a web application to gather QR codes and similar.
+It also allows easy upscaling to other machines, support for [RPi](https://www.raspberrypi.org), and general familiarity. Ubuntu Core offers "Ubuntu Frame" as a key solution to host a web application to gather QR codes and similar.
 
 Unknowns:
 
@@ -40,7 +40,7 @@ One of the major pros of Ubuntu Core is the long life of an LTS release, with Ub
 
 ## Alpine Based Solution
 
-Alpine is based around muslc, and is *in general* considerably smaller than Ubuntu. Alpine might be better for constrained hardware, *but* I'm less familiar with it in a general sense. Furthermore, if interaction with existing Glibc binaries needs to happen, alpine is difficult, as such things are not supported.
+[Alpine](https://www.alpinelinux.org/) is based around [muslc](https://musl.libc.org/), and is *in general* considerably smaller than Ubuntu. Alpine might be better for constrained hardware, *but* I'm less familiar with it in a general sense. Furthermore, if interaction with existing Glibc binaries needs to happen, alpine is difficult, as such things are not supported.
 
 Alpine has generally excellent hardware and environment support, *but*, need to consider support life as a whole. Mostly just boils down to I have to do more research.
 

--- a/docs/hardware_deployment_stuff.md
+++ b/docs/hardware_deployment_stuff.md
@@ -1,6 +1,6 @@
 # Various hardware/deployment scenarios
 
-Vaksina plus its API are designed to have as minium requirements as possible. The goal is to keep as code in base Python libraries as is possible, and as few dependencies as possible
+Vaksina plus its API are designed to have as minimum requirements as possible. The goal is to keep as code in base Python libraries as is possible, and as few dependencies as possible
 
 Current thought process towards deployment image:
 
@@ -24,11 +24,11 @@ Ability to interface with external hardware:
 
 We may end up deploying multiple solutions ... We'll see ...
 
-An important factor is this needs to be entirely turnkey. You download a premade IMG file, you pop it in, and it boots regardless. No configuration, or changes are needed. Furthermore, no internet access or network connectivity of any sort is needed. All information is locally stored.
+An important factor is this needs to be entirely turnkey. You download a pre-made IMG file, you pop it in, and it boots regardless. No configuration, or changes are needed. Furthermore, no internet access or network connectivity of any sort is needed. All information is locally stored.
 
 ## Ubuntu Core Based Solution
 
-The use of Ubuntu Core as a base has all needed dependencies pre-packaged, and is trivial to deploy Docker containers on.
+The use of Ubuntu Core as a base has all the needed dependencies pre-packaged, and is trivial to deploy Docker containers on.
 
 It also allows easy upscaling to other machines, support for RPi, and general familiarity. Ubuntu Core offers "Ubuntu Frame" as a key solution to host a web application to gather QR codes and similar.
 

--- a/docs/objects_stuff.md
+++ b/docs/objects_stuff.md
@@ -11,7 +11,7 @@ processing
 ## CardObjects
 
 A card object represents a given digital card, and is handled by other classes to
-determine if the holder is currently up to date with their vaccination records
+determine if the holder is currently up-to-date with their vaccination records
 
 CardObjects are a generic superclass for each type of card, i.e. SHC, Green Pass, etc.
 
@@ -21,7 +21,7 @@ A card MUST have the following information
 * Date of Birth
 * Immunization Record (if possible)
 
-CardObjects get passed to Validation modules to determine if the holder is *actually* vaccinated
+CardObjects are passed to Validation modules to determine if the holder is *actually* vaccinated
 
 ## Person
 
@@ -39,4 +39,4 @@ A Person contains the following information
   * Could include PCR tests/rapid antigen
   * Must include vaccination complete with status
 
-Can be processed by a validator module to the determine status
+Can be processed by a validator module to determine status

--- a/docs/ongoing_development_notes.txt
+++ b/docs/ongoing_development_notes.txt
@@ -19,7 +19,7 @@ So immunization record exists in the form of:
  Need to create Vaccination Record types that convert medical coding to Vaccine object(?)
   - is this the best way to handle it?
 
- Once Person/Immunization records assiocated with, we need a parser then checks
+ Once Person/Immunization records associated with, we need a parser then checks
  immunizations, and determined if they're good to go, plus time from initial shot
  per COVID protocols. This should be implemented as a generic "class" that takes
  Person record in, returns True/False to determine if someone is vaccinated, which

--- a/tests/test_fhir_parser.py
+++ b/tests/test_fhir_parser.py
@@ -59,16 +59,16 @@ class TestFHIRParser(unittest.TestCase):
 
     def validate_jane_c_anyperson(self, p):
         """This is the test data from official example 01"""
-        comparsion_dob = datetime.fromisoformat("1961-01-20")
+        comparison_dob = datetime.fromisoformat("1961-01-20")
 
         self.assertEqual(len(p.names), 1)
         self.assertEqual(p.names[0], "Jane C. Anyperson")
-        self.assertEqual(p.dob, comparsion_dob)
+        self.assertEqual(p.dob, comparison_dob)
         self.assertEqual(len(p.immunizations), 2)
 
-        comparsion_date_1 = datetime.fromisoformat("2021-01-01")
+        comparison_date_1 = datetime.fromisoformat("2021-01-01")
 
-        if p.immunizations[0].date_given == comparsion_date_1:
+        if p.immunizations[0].date_given == comparison_date_1:
             first_shot = p.immunizations[0]
             second_short = p.immunizations[1]
         else:
@@ -87,16 +87,16 @@ class TestFHIRParser(unittest.TestCase):
 
     def validate_john_b_anyperson(self, p):
         """Validate John from Example 0"""
-        comparsion_dob = datetime.fromisoformat("1951-01-20")
+        comparison_dob = datetime.fromisoformat("1951-01-20")
 
         self.assertEqual(len(p.names), 1)
         self.assertEqual(p.names[0], "John B. Anyperson")
-        self.assertEqual(p.dob, comparsion_dob)
+        self.assertEqual(p.dob, comparison_dob)
         self.assertEqual(len(p.immunizations), 2)
 
-        comparsion_date_1 = datetime.fromisoformat("2021-01-01")
+        comparison_date_1 = datetime.fromisoformat("2021-01-01")
 
-        if p.immunizations[0].date_given == comparsion_date_1:
+        if p.immunizations[0].date_given == comparison_date_1:
             first_shot = p.immunizations[0]
             second_short = p.immunizations[1]
         else:
@@ -122,7 +122,7 @@ class TestFHIRParser(unittest.TestCase):
         pass
 
     def test_parse_person_record(self):
-        """Tests if how we handle a Person entry"""
+        """Tests how we handle a Person entry"""
         fhir_parser = fp.FHIRParser(self.vaccine_mgr)
 
         with open(TEST_PATIENT) as f:
@@ -136,10 +136,10 @@ class TestFHIRParser(unittest.TestCase):
         # patients in a given record, and I don't want to
         # blow unexpectedly
 
-        comparsion_time = datetime.fromisoformat("1951-01-20")
+        comparison_time = datetime.fromisoformat("1951-01-20")
         self.assertEqual(len(patient.names), 1)
         self.assertEqual(patient.names[0], "John B. Anyperson")
-        self.assertEqual(patient.dob, comparsion_time)
+        self.assertEqual(patient.dob, comparison_time)
 
     def test_parse_person_record(self):
         """Tests if how we handle a Person entry"""
@@ -159,10 +159,10 @@ class TestFHIRParser(unittest.TestCase):
             json_parse = json.loads(f.read())
 
         i = fhir_parser.parse_immunization_record(json_parse)
-        issurance_date_test = datetime.fromisoformat("2021-01-01")
+        issuance_date_test = datetime.fromisoformat("2021-01-01")
 
         self.assertEqual(i.vaccine_administered.vaccine_identifier, "MODERNA")
-        self.assertEqual(i.date_given, issurance_date_test)
+        self.assertEqual(i.date_given, issuance_date_test)
         self.assertEqual(i.lot_number, "0000001")
         self.assertEqual(i._shc_parent_object, "resource:0")
 
@@ -196,7 +196,7 @@ class TestFHIRParser(unittest.TestCase):
 
         self.assertEqual(len(p.immunizations), 1)
 
-    def test_fhir_bunder_with_additional_sections(self):
+    def test_fhir_bundle_with_additional_sections(self):
         """Test that we gracefully handle FHIR with additional sections"""
         fhir_parser = fp.FHIRParser(self.vaccine_mgr)
 
@@ -207,14 +207,14 @@ class TestFHIRParser(unittest.TestCase):
 
         self.assertEqual(len(p_list), 1)
         p = p_list[0]
-        comparsion_dob = datetime.fromisoformat("1951-01-20")
+        comparison_dob = datetime.fromisoformat("1951-01-20")
 
         self.assertEqual(len(p.names), 1)
         self.assertEqual(p.names[0], "John B. Anyperson")
-        self.assertEqual(p.dob, comparsion_dob)
+        self.assertEqual(p.dob, comparison_dob)
         self.assertEqual(len(p.immunizations), 2)
 
-    def test_fhir_bunder_non_bundle(self):
+    def test_fhir_bundle_non_bundle(self):
         """Test that we only accept bundles correctly"""
         fhir_parser = fp.FHIRParser(self.vaccine_mgr)
 
@@ -253,7 +253,7 @@ class TestFHIRParser(unittest.TestCase):
         self.validate_john_b_anyperson(john_p)
         self.validate_jane_c_anyperson(jane_p)
 
-    def test_proepr_bailout_with_duplicate_url(self):
+    def test_proper_bailout_with_duplicate_url(self):
         """Test decoding official sample 00 fhir bundle"""
         fhir_parser = fp.FHIRParser(self.vaccine_mgr)
 
@@ -263,9 +263,9 @@ class TestFHIRParser(unittest.TestCase):
         with self.assertRaises(ValueError):
             fhir_parser.parse_bundle_to_persons(json_parse)
 
-    ## Down here, we test that we can successfully read/load official
-    ## specification data. Example 2 is expected to fail as is it is
-    ## not a valid COVID19 card
+    # Down here, we test that we can successfully read/load official
+    # specification data. Example 2 is expected to fail as is it is
+    # not a valid COVID19 card
 
     def test_parse_official_example_00(self):
         """Test decoding official sample 00 fhir bundle"""
@@ -313,9 +313,9 @@ class TestFHIRParser(unittest.TestCase):
 
         self.assertEqual(len(p_list), 1)
         p = p_list[0]
-        comparsion_dob = datetime.fromisoformat("1960-04-22")
+        comparison_dob = datetime.fromisoformat("1960-04-22")
 
         self.assertEqual(len(p.names), 1)
         self.assertEqual(p.names[0], "Johnny Revoked")
-        self.assertEqual(p.dob, comparsion_dob)
+        self.assertEqual(p.dob, comparison_dob)
         self.assertEqual(len(p.immunizations), 2)

--- a/tests/test_fhir_parser.py
+++ b/tests/test_fhir_parser.py
@@ -141,7 +141,7 @@ class TestFHIRParser(unittest.TestCase):
         self.assertEqual(patient.names[0], "John B. Anyperson")
         self.assertEqual(patient.dob, comparison_time)
 
-    def test_parse_person_record(self):
+    def test_parse_person_record_error(self):
         """Tests if how we handle a Person entry"""
         fhir_parser = fp.FHIRParser(self.vaccine_mgr)
 

--- a/tests/test_fhir_parser.py
+++ b/tests/test_fhir_parser.py
@@ -25,13 +25,17 @@ from datetime import datetime
 
 import vaksina.fhir_parser as fp
 import vaksina.vaccines as vac
+import os
 
-TEST_DATA_SHC = "tests/data/shc/"
-TEST_DATA_FHIR = "tests/data/fhir/"
+
+dir_path = os.path.dirname(os.path.realpath(__file__)) + '/'
+
+TEST_DATA_SHC = dir_path + "data/shc/"
+TEST_DATA_FHIR = dir_path + "data/fhir/"
 
 TEST_OFFICIAL_DATA_ROOT = TEST_DATA_SHC + "official/"
 
-VACCINE_INFO = "tests/data/vaccine_info.json"
+VACCINE_INFO = dir_path + "data/vaccine_info.json"
 
 # Example test file 2 doesn't have any patient data in it
 TEST_PATIENT = TEST_DATA_FHIR + "patient_data.json"

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -34,5 +34,5 @@ class TestSkeleton(unittest.TestCase):
         pass
 
     def test_hello(self):
-        """Tests that the test envirnment exists"""
+        """Tests that the test environment exists"""
         pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,12 +24,16 @@ import unittest
 
 from jose import jwk
 from jose.constants import ALGORITHMS
+import os
 
 import vaksina.utils as u
 
+dir_path = os.path.dirname(os.path.realpath(__file__)) + '/'
+
 SHC_OFFICIAL_KEY = (
-    'tests/data/shc/official/keys/jwks.json'
+    dir_path + 'data/shc/official/keys/jwks.json'
 )
+
 
 class TestUtils(unittest.TestCase):
     """Tests misc utility functions"""

--- a/tests/test_vaccines.py
+++ b/tests/test_vaccines.py
@@ -64,7 +64,7 @@ class TestVaccineManager(unittest.TestCase):
         self.assertIsNotNone(vaccine)
         self.assertEqual(vaccine.vaccine_identifier, "MODERNA")
 
-    def test_vaccine_by_fhir_code_single(self):
+    def test_vaccine_by_fhir_code_multiple(self):
         """Ensures that we can properly load vaccine with multiple codes"""
 
         vac_mgr = get_vac_manager()

--- a/tests/test_vaccines.py
+++ b/tests/test_vaccines.py
@@ -22,8 +22,11 @@
 import unittest
 
 import vaksina.vaccines as vac
+import os
 
-VACCINE_INFO = "tests/data/vaccine_info.json"
+dir_path = os.path.dirname(os.path.realpath(__file__)) + '/'
+
+VACCINE_INFO = dir_path + "data/vaccine_info.json"
 
 
 def get_vac_manager():


### PR DESCRIPTION
- typos in docs
- added some links (Alpine, Ubuntu Core and etc.) to the docs
- typos in tests
- fixed duplicate test names
- changed file paths from relative to absolute. Otherwise, tests would raise FileNotFound in PyCharm (on Windows)