### PR TITLE
Typos in code/comments, some cleanup and fixed parse_immunization_record?

### DIFF
--- a/tests/test_fhir_parser.py
+++ b/tests/test_fhir_parser.py
@@ -158,7 +158,7 @@ class TestFHIRParser(unittest.TestCase):
         with open(TEST_IMMUNIZATION) as f:
             json_parse = json.loads(f.read())
 
-        i = fhir_parser.parse_immunization_record(json_parse)
+        i = fhir_parser.parse_immunization_records(json_parse)[0]
         issurance_date_test = datetime.fromisoformat("2021-01-01")
 
         self.assertEqual(i.vaccine_administered.vaccine_identifier, "MODERNA")
@@ -174,7 +174,7 @@ class TestFHIRParser(unittest.TestCase):
             json_parse = json.loads(f.read())
 
         with self.assertRaises(ValueError):
-            i = fhir_parser.parse_immunization_record(json_parse)
+            i = fhir_parser.parse_immunization_records(json_parse)
 
     def test_immunization_parse_with_non_immunization(self):
         """Tests graceful exit if we have unknown vaccine coding"""
@@ -184,7 +184,7 @@ class TestFHIRParser(unittest.TestCase):
             json_parse = json.loads(f.read())
 
         with self.assertRaises(ValueError):
-            i = fhir_parser.parse_immunization_record(json_parse)
+            i = fhir_parser.parse_immunization_records(json_parse)
 
     def test_incomplete_immunization_records_are_not_handled(self):
         """Test that logged in error or similar case is not counted"""

--- a/vaksina/card.py
+++ b/vaksina/card.py
@@ -36,10 +36,11 @@ class Card(object):
         self._person_count = self._person_count + 1
 
     def to_dict(self):
-        """Convert Card object to dictionary for validation"""
-        c_dict = {}
-        c_dict["card_type"] = self.card_type
-        c_dict["issued_by"] = self.issued_by
+        """Convert CardObject to dictionary for validation"""
+        c_dict = {
+            "card_type": self.card_type,
+            "issued_by": self.issued_by
+        }
         person_dict = {}
 
         for pkey, person in self.persons.items():

--- a/vaksina/fhir_parser.py
+++ b/vaksina/fhir_parser.py
@@ -102,7 +102,8 @@ class FHIRParser(object):
     #   "birthDate": "1951-01-20"
     # }
 
-    def parse_person_record(self, resource):
+    @staticmethod
+    def parse_person_record(resource):
         """Converts FHIR data into People Records
 
         NOTE: Currently only data related to completed vaccinations

--- a/vaksina/fhir_parser.py
+++ b/vaksina/fhir_parser.py
@@ -50,7 +50,7 @@ class FHIRParser(object):
     #  'vaccineCode': {'coding': [{'code': '207',
     #                              'system': 'http://hl7.org/fhir/sid/cvx'}]}}
 
-    def parse_immunization_record(self, resource):
+    def parse_immunization_records(self, resource):
         """Confirms FHIR Immunization record to object"""
 
         # It's possible that multiple vaccines can be given in
@@ -86,7 +86,7 @@ class FHIRParser(object):
             # so register the specific vaccine, right now, just handle the "code"
             immunizations.append(immunization)
 
-        return immunization
+        return immunizations
 
     # {
     #   "resourceType": "Patient",
@@ -186,7 +186,7 @@ class FHIRParser(object):
                     # FIXME: debug logger
                     continue
 
-                immunizations.append(self.parse_immunization_record(resource))
+                immunizations.extend(self.parse_immunization_records(resource))
 
             # Coverage isn't properly handling an else class here
             #

--- a/vaksina/fhir_parser.py
+++ b/vaksina/fhir_parser.py
@@ -54,7 +54,7 @@ class FHIRParser(object):
         """Confirms FHIR Immunization record to object"""
 
         # It's possible that multiple vaccines can be given in
-        # single day. This isn't done for COVID per say, but
+        # single day. This isn't done for COVID per se, but
         # because FHIR is a general purpose specification, we
         # should handle this, especially if there are future
         # multishot COVID vaccinations that *are* given at later
@@ -75,7 +75,7 @@ class FHIRParser(object):
                 resource["occurrenceDateTime"]
             )
 
-            # So dependenting on the code we get determines the type
+            # So depending on the code we get determines the type
             # of vaccine that was issued
             immunization.vaccine_administered = (
                 self.vaccine_mgr.get_vaccine_by_fhir_code(int(code["code"]))
@@ -148,7 +148,7 @@ class FHIRParser(object):
         seen_full_urls = set()
 
         # URLs in SMART Health Cards are freeform, and are used to
-        # link objects together. Its possible in a case of multiple
+        # link objects together. It's possible in a case of multiple
         # people on a given card that a URL duplication could be used
         # as an attack. As a safeguard, load all URLs as seen, and
         # bail out *if* we get a duplicate
@@ -169,7 +169,7 @@ class FHIRParser(object):
 
                 # print(vars(person))
             elif resource["resourceType"] == "Immunization":
-                # ok, special case here, we only handle an immunizaiton
+                # ok, special case here, we only handle an immunization
                 # if it was actually completed, otherwise, disregard
                 if resource["status"] != "completed":
                     # FHIR specification notes that status can be one
@@ -193,7 +193,7 @@ class FHIRParser(object):
             # if
             # FIXME: Implement debug logger
 
-        # Assiocate immunity records with patient records
+        # Associate immunity records with patient records
         for immunization in immunizations:
             if immunization._shc_parent_object not in person_uris:
                 raise ValueError("ERROR: DANGLING REFERENCE TO SHC PARENT OBJECT")

--- a/vaksina/immunization.py
+++ b/vaksina/immunization.py
@@ -32,8 +32,9 @@ class Immunization(object):
         return self.vaccine_administered == other
 
     def to_dict(self):
-        i_dict = {}
-        i_dict["vaccine_administered"] = self.vaccine_administered.vaccine_identifier
-        i_dict["date_given"] = self.date_given.strftime("%Y-%m-%d")
-        i_dict["lot_number"] = self.lot_number
+        i_dict = {
+            "vaccine_administered": self.vaccine_administered.vaccine_identifier,
+            "date_given": self.date_given.strftime("%Y-%m-%d"),
+            "lot_number": self.lot_number
+        }
         return i_dict

--- a/vaksina/person.py
+++ b/vaksina/person.py
@@ -44,7 +44,7 @@ class Person(object):
         self.immunizations = []
         """Immunizations are vaksina.Immunization objects, formed as a list.
 
-        Only completed vaccitions (that is status = "completed" in SHC, or similar
+        Only completed vaccinations (that is status = "completed" in SHC, or similar
         in other cards) is included, since this is not intended as a general purpose
         health record tool, merely a validator for COVID-19 QR codes
         """

--- a/vaksina/person.py
+++ b/vaksina/person.py
@@ -51,8 +51,7 @@ class Person(object):
 
     def to_dict(self):
         """Serializes data to a dictionary for use in JSON, etc."""
-        person_dict = {}
-        person_dict["name"] = []
+        person_dict = {"name": []}
         for name in self.names:
             person_dict["name"].append(name)
 

--- a/vaksina/shc/ctm.py
+++ b/vaksina/shc/ctm.py
@@ -51,7 +51,6 @@ class ShcCardTypeManager(vaksina.CardManager):
         for p in parts:
             b64_data += chr(int(p) + 45)
 
-
         # So, to validate the turducken (that is say SHC data)
         # we need to unpack without checking the signature. Then
         # we can get the iss field, try and get that key from the
@@ -60,7 +59,7 @@ class ShcCardTypeManager(vaksina.CardManager):
         unvalidated_vac_header = jws.get_unverified_header(b64_data)
         unvalidated_vac_data = jws.get_unverified_claims(b64_data)
         raw_unsigned_vax_data = str(
-            zlib.decompress(unvalidated_vac_data, wbits=-15), "utf-8"
+            zlib.decompress(bytes(unvalidated_vac_data), wbits=-15), "utf-8"
         )
 
         unsigned_vax_data = json.loads(raw_unsigned_vax_data)
@@ -80,7 +79,7 @@ class ShcCardTypeManager(vaksina.CardManager):
             )
 
         verified_data = jws.verify(b64_data, declared_key, ALGORITHMS.ES256)
-        vax_data = json.loads(str(zlib.decompress(verified_data, wbits=-15), "utf-8"))
+        vax_data = json.loads(str(zlib.decompress(bytes(verified_data), wbits=-15), "utf-8"))
 
         # Assuming we got this far, ensure that this card complies with
         # the specifications we *assume* exist*
@@ -97,9 +96,9 @@ class ShcCardTypeManager(vaksina.CardManager):
                 is_covid19_card = True
 
         if (
-            is_health_card == False
-            or is_covid19_card == False
-            or is_immunization_card == False
+            is_health_card is False
+            or is_covid19_card is False
+            or is_immunization_card is False
         ):
             raise ValueError("Not a supported type of card")
 

--- a/vaksina/shc/key_management.py
+++ b/vaksina/shc/key_management.py
@@ -71,9 +71,9 @@ class KeyManagement(object):
                 print("ERROR: not the right type of curve")
                 continue
 
-            # make sure we have x and why
+            # make sure we have x and y
             if "x" not in key or "y" not in key:
-                print("x/y cooridors not found!")
+                print("x/y coordinates not found!")
                 continue
 
             if "d" in key:

--- a/vaksina/shc/key_management.py
+++ b/vaksina/shc/key_management.py
@@ -47,6 +47,7 @@ class KeyManagement(object):
         # else:
         # raise ValueError("Cowardly refusing to enroll duplicate iss keystore")
 
+    @staticmethod
     def _load_pubkey(jwt_pubkey):
         """Creates jose pubkey objects from JWT JSON"""
 

--- a/vaksina/utils.py
+++ b/vaksina/utils.py
@@ -28,6 +28,7 @@ import json
 import base64
 import hashlib
 
+
 def _generate_kid_for_jwk_dict(jwks_dict):
     """Generates KID token per RFC 7638
     
@@ -45,11 +46,12 @@ def _generate_kid_for_jwk_dict(jwks_dict):
     if jwks_dict['kty'] != "EC": 
         raise ValueError("only EC JWKs supported!")
 
-    kid_base = {}
-    kid_base['crv'] = jwks_dict['crv']
-    kid_base['kty'] = jwks_dict['kty']
-    kid_base['x'] = jwks_dict['x']
-    kid_base['y'] = jwks_dict['y']
+    kid_base = {
+        'crv': jwks_dict['crv'],
+        'kty': jwks_dict['kty'],
+        'x': jwks_dict['x'],
+        'y': jwks_dict['y']
+    }
     json_serial = json.dumps(kid_base, sort_keys=True, separators=(',', ':'))
     sha256_hash = hashlib.sha256(json_serial.encode('utf-8')).digest()
     b64_hash = base64.urlsafe_b64encode(sha256_hash)

--- a/vaksina/utils.py
+++ b/vaksina/utils.py
@@ -32,7 +32,7 @@ def _generate_kid_for_jwk_dict(jwks_dict):
     """Generates KID token per RFC 7638
     
     Unfortunately, python-jose doesn't have a way to generate key IDs for a JWK
-    according to RFC 7638, and its the only permissive licensed JWT library that
+    according to RFC 7638, and it's the only permissive licensed JWT library that
     has support for ECs out of the box. This only handles ECs as of right now
 
     This takes a raw JWK dict, so you can load JSON data and pass it straight in

--- a/vaksina/vaccines.py
+++ b/vaksina/vaccines.py
@@ -79,7 +79,7 @@ class Vaccine(object):
         return self.vaccine_identifier == other.vaccine_identifier
 
     def load_from_json(v):
-        """Deserailizes vaccine information from JSON file"""
+        """Deserializes vaccine information from JSON file"""
         vax = Vaccine()
         vax.vaccine_identifier = v["vaccine_identifier"]
         vax.required_doses = v["required_doses"]

--- a/vaksina/vaccines.py
+++ b/vaksina/vaccines.py
@@ -78,6 +78,7 @@ class Vaccine(object):
     def __eq__(self, other):
         return self.vaccine_identifier == other.vaccine_identifier
 
+    @staticmethod
     def load_from_json(v):
         """Deserializes vaccine information from JSON file"""
         vax = Vaccine()

--- a/vaksina/validators.py
+++ b/vaksina/validators.py
@@ -63,7 +63,7 @@ class Validators(object):
           - 2 weeks must pass from administration date to current date
 
         Otherwise, in a two shot vaccine, the following rules apply
-          - each vaccine must be admined 17 days apart with 4 day grace period
+          - each vaccine must be administered 17 days apart with 4 day grace period
           - 2 weeks from the date of administration
 
         This standard does not account for any boosters in use.
@@ -78,7 +78,7 @@ class Validators(object):
         # Get immunizations for person
         immunizations = person.immunizations
 
-        # Handle the simplier one shot test case now ...
+        # Handle the simpler one shot test case now ...
         for immunization in immunizations:
             for vaccine in one_shot_vaccines:
                 if immunization.is_vaccine(vaccine):

--- a/vaksina/validators.py
+++ b/vaksina/validators.py
@@ -39,8 +39,7 @@ class ValidationResult(object):
         self.validation_errors = None
 
     def to_dict(self):
-        vr_dict = {}
-        vr_dict["card_validation_status"] = self.card_validation_status
+        vr_dict = {"card_validation_status": self.card_validation_status}
         if self.validation_errors is not None:
             vr_dict["validation_errors"] = self.validation_errors
         return vr_dict


### PR DESCRIPTION
- fixed typos in code
- cleaned up some code (PyCharm linter errors/warnings)
- fixed parse_immunization_record?

On the last one (`parse_immunization_record`), the comment inside it states:

> **_It's possible that multiple vaccines can be given in
    single day_**. This isn't done for COVID per se, but
    because FHIR is a general purpose specification, **_we
    should handle this_**, especially if there are future
    multishot COVID vaccinations that *are* given at later
    point, because data structures are important

If I understand this correctly, the method should handle multiple immunization records, store them in an list and return them all.
If that is the intended behaviour, then I fixed it. If not then this should be reverted, and the method refactored, since before it created a list of imunizations that was filled but never used, and the method only ever returned the last parsed immunization, and if the received dictionarry was empty/had no immunizations, the method would return a variable before initialized (so my PyCharm linter was freaking out on that :P)